### PR TITLE
Response Message Builder 추가

### DIFF
--- a/StatusCode/StatusCode.cpp
+++ b/StatusCode/StatusCode.cpp
@@ -1,7 +1,7 @@
 #include "StatusCode.hpp"
 
 
-std::unordered_map<std::string, std::string> IrcStatusCodeHelper::statusMap;
+std::map<std::string, std::string> IrcStatusCodeHelper::statusMap;
 bool IrcStatusCodeHelper::init = false;
 
 void IrcStatusCodeHelper::initialMap()
@@ -46,7 +46,7 @@ std::string& IrcStatusCodeHelper::getStatusCode(const std::string& statusName)
 {
     if (init == false)
         throw std::invalid_argument("statusMap is not initializied");
-    const std::unordered_map<std::string, std::string>::iterator it = statusMap.find(statusName);
+    const std::map<std::string, std::string>::iterator it = statusMap.find(statusName);
     if (it != statusMap.end()){
         return it->second;
     } else {

--- a/StatusCode/StatusCode.hpp
+++ b/StatusCode/StatusCode.hpp
@@ -4,12 +4,11 @@
 #include <string>
 #include <map>
 #include <stdexcept>
-#include <unordered_map>
 
 class IrcStatusCodeHelper
 {
     private:
-        static          std::unordered_map<std::string, std::string> statusMap;
+        static          std::map<std::string, std::string> statusMap;
         static bool     init;
     public:
         static void initialMap();

--- a/response/Response.cpp
+++ b/response/Response.cpp
@@ -1,0 +1,52 @@
+#include "Response.hpp"
+
+#include <exception>
+
+static const std::string partDelimiter = ":";
+static const std::string messageEndingDelimeter = "\r\n";
+static const std::string space = " ";
+
+std::string Response::build(std::string responseCode, std::string prefix,
+                            std::vector<std::string> params,
+                            std::string trailer) {
+  if (params.size() > 14) {
+    throw std::invalid_argument("파라미터의 개수는 14개 이하여야 합니다.");
+  }
+
+  std::string msg = "";
+
+  // prefix 추가
+  msg.append(partDelimiter + prefix + space);
+  // 응답 코드 추가
+  msg.append(responseCode);
+  // 파라미터가 존재할 경우추가
+  for (size_t i = 0; i < params.size(); i++) {
+    msg.append(space + params.at(i));
+  }
+  // 트레일러가 존재할 경우 추가
+  if (!trailer.empty()) {
+    msg.append(space + partDelimiter + trailer);
+  }
+  // CR-LF 추가
+  msg.append(messageEndingDelimeter);
+
+  if (msg.size() > 512) {
+    throw std::invalid_argument("메시지의 길이는 512byte 이하여야 합니다.");
+  }
+
+  return msg;
+}
+
+std::string Response::build(std::string responseCode, std::string prefix,
+                            std::vector<std::string> params) {
+  return build(responseCode, prefix, params, "");
+}
+
+std::string Response::build(std::string responseCode, std::string prefix) {
+  std::vector<std::string> emptyVector;
+  return build(responseCode, prefix, emptyVector);
+}
+
+std::string Response::build(std::string responseCode) {
+  return build(responseCode, DEFAULT_PREFIX);
+}

--- a/response/Response.hpp
+++ b/response/Response.hpp
@@ -1,0 +1,20 @@
+#ifndef RESPONSE_HPP
+#define RESPONSE_HPP
+
+#define DEFAULT_PREFIX "webserv.com"
+
+#include <string>
+#include <vector>
+
+class Response {
+ public:
+  static std::string build(std::string responseCode, std::string prefix,
+                           std::vector<std::string> params,
+                           std::string trailer);
+  static std::string build(std::string responseCode, std::string prefix,
+                           std::vector<std::string> params);
+  static std::string build(std::string responseCode, std::string prefix);
+  static std::string build(std::string responseCode);
+};
+
+#endif

--- a/response/Response.hpp
+++ b/response/Response.hpp
@@ -1,7 +1,7 @@
 #ifndef RESPONSE_HPP
 #define RESPONSE_HPP
 
-#define DEFAULT_PREFIX "webserv.com"
+#define DEFAULT_PREFIX "ircserv.com"
 
 #include <string>
 #include <vector>


### PR DESCRIPTION
응답 메시지 빌더를 추가하였습니다.
아래 네가지 파라미터를 받는 build 메서드를 추가했습니다.

```
1. string responseCode   (required)
2. string prefix         (optional)
3. vector<string> params (optional)
4. string trailer        (optional)

optional로 표시된 파라미터가 주어지지 않는 경우 기본값으로 대체되거나 응답 메시지에 추가되지 않습니다.
```

```
<용례>
Response::build("314", 
                "testserver.com", 
                params,
                "trailer test!!");

반환값 => :testserver.com 314 param1 param2 :trailer test!!



Response::build("314", 
                "trailer test!!");

반환값 => :ircserv.com 314 :trailer test!!
```

