### PR TITLE
C++11 메서드들을 c++98 표준에 맞도록 수정했습니다.

### DIFF
--- a/StatusCode/StatusCode.cpp
+++ b/StatusCode/StatusCode.cpp
@@ -1,10 +1,10 @@
 #include "StatusCode.hpp"
 
 
-std::map<std::string, std::string> IrcStatusCodeHelper::statusMap;
-bool IrcStatusCodeHelper::init = false;
+std::map<std::string, std::string> StatusCode::statusMap;
+bool StatusCode::init = false;
 
-void IrcStatusCodeHelper::initialMap()
+void StatusCode::initialMap()
 {
     statusMap["RPL_WELCOME"] = "001"; // connect is success
     statusMap["RPL_BOUNCE"] = "005"; // server is already fully
@@ -42,7 +42,7 @@ void IrcStatusCodeHelper::initialMap()
 }
 
 
-std::string& IrcStatusCodeHelper::getStatusCode(const std::string& statusName)
+std::string& StatusCode::getStatusCode(const std::string& statusName)
 {
     if (init == false)
         throw std::invalid_argument("statusMap is not initializied");

--- a/StatusCode/StatusCode.cpp
+++ b/StatusCode/StatusCode.cpp
@@ -1,7 +1,7 @@
 #include "StatusCode.hpp"
 
 
-std::unordered_map<std::string, std::string> IrcStatusCodeHelper::statusMap;
+std::map<std::string, std::string> IrcStatusCodeHelper::statusMap;
 bool IrcStatusCodeHelper::init = false;
 
 void IrcStatusCodeHelper::initialMap()
@@ -46,7 +46,7 @@ std::string& IrcStatusCodeHelper::getStatusCode(const std::string& statusName)
 {
     if (init == false)
         throw std::invalid_argument("statusMap is not initializied");
-    const std::unordered_map<std::string, std::string>::iterator it = statusMap.find(statusName);
+    const std::map<std::string, std::string>::iterator it = statusMap.find(statusName);
     if (it != statusMap.end()){
         return it->second;
     } else {

--- a/StatusCode/StatusCode.hpp
+++ b/StatusCode/StatusCode.hpp
@@ -4,12 +4,11 @@
 #include <string>
 #include <map>
 #include <stdexcept>
-#include <unordered_map>
 
 class IrcStatusCodeHelper
 {
     private:
-        static          std::unordered_map<std::string, std::string> statusMap;
+        static          std::map<std::string, std::string> statusMap;
         static bool     init;
     public:
         static void initialMap();

--- a/StatusCode/StatusCode.hpp
+++ b/StatusCode/StatusCode.hpp
@@ -5,7 +5,7 @@
 #include <map>
 #include <stdexcept>
 
-class IrcStatusCodeHelper
+class StatusCode
 {
     private:
         static          std::map<std::string, std::string> statusMap;

--- a/request/Command.cpp
+++ b/request/Command.cpp
@@ -2,11 +2,19 @@
 
 #include <algorithm>
 
-bool isValidFormat(const std::string &command) {
+bool isValidFormat(const std::string& command) {
   if (command.length() < 1) {
     return false;
   }
   return true;
+}
+
+std::string toUpperCase(const std::string& str) {
+  std::string upperStr = str;
+  for (size_t i = 0; i < upperStr.length(); ++i) {
+    upperStr[i] = std::toupper(upperStr[i]);
+  }
+  return upperStr;
 }
 
 Command::Command() {}
@@ -20,8 +28,7 @@ void Command::set(std::string command) {
     throw std::invalid_argument("command 메시지 형식이 잘못되었습니다.");
   }
 
-  std::transform(command.begin(), command.end(), command.begin(), std::toupper);
-  this->command = command;
+  this->command = toUpperCase(command);
 }
 
 std::string Command::getCommand() const { return command; }

--- a/request/Command.hpp
+++ b/request/Command.hpp
@@ -1,7 +1,7 @@
 #ifndef COMMAND_HPP
 #define COMMAND_HPP
 
-#include <exception>
+#include <stdexcept>
 #include <string>
 
 class Command {

--- a/request/Parameter.hpp
+++ b/request/Parameter.hpp
@@ -1,7 +1,7 @@
 #ifndef PARAMETER_HPP
 #define PARAMETER_HPP
 
-#include <exception>
+#include <stdexcept>
 #include <string>
 #include <vector>
 

--- a/request/Prefix.hpp
+++ b/request/Prefix.hpp
@@ -1,7 +1,7 @@
 #ifndef PREFIX_HPP
 #define PREFIX_HPP
 
-#include <exception>
+#include <stdexcept>
 #include <string>
 
 class Prefix {

--- a/request/Request.cpp
+++ b/request/Request.cpp
@@ -1,6 +1,6 @@
 #include "Request.hpp"
 
-#include <exception>
+#include <stdexcept>
 
 static const std::string messageDelimeter = " ";
 static const std::string messageEndingKeyword = "\r\n";


### PR DESCRIPTION
아래와 같은 사항들을 수정했습니다.

1. IrcStatusCodeHelper 클래스의 이름을 StatusCode로 수정했습니다.
2. StatusCode 클래스 내부에서 unordered_map 컨테이너 대신 map을 사용하도록 수정했습니다.
3. Command 클래스 내부에서 transform 메서드를 사용하지 않도록 수정했습니다. (toupper 메서드를 사용합니다.)
4. request 디렉터리 내부에서 \<exception\> 헤더 대신 \<stdexcept\>를 사용하도록 수정했습니다.
