### PR TITLE
KICK 수정

### DIFF
--- a/Controller/Controller.cpp
+++ b/Controller/Controller.cpp
@@ -9,6 +9,7 @@
 #include "Privmsg.hpp"
 #include "Topic.hpp"
 #include "UserCmd.hpp"
+#include "Mode.hpp"
 
 Controller::Controller(Request &req, User *user) : request(req), user(user) {}
 
@@ -77,8 +78,8 @@ void Controller::execute() {
       if (request.parameter().getParameters()[0].find('#') == std::string::npos)
         send(user->getfd(), ":ircserv.com  MODE root :+i\r\n",
              sizeof(":ircserv.com  MODE root :+i\r\n"), 0);
-      // Mode mode(request, this->user);
-      // mode.excute();
+        Mode mode(request, this->user);
+        mode.execute();
     }
     else {
       fd_set fd_write;

--- a/Controller/Kick.cpp
+++ b/Controller/Kick.cpp
@@ -6,7 +6,6 @@ Kick::Kick(Request req, User *user) : ICommand(req, user)
     if (req.parameter().getParameters().size() < 1)
     {
         Channel temp = Channel();
-        std::cout << temp.getName();
         this->channel = &temp;
     }
     else if(channelMap->exists(req.parameter().getParameters()[0].substr(1)))
@@ -15,7 +14,6 @@ Kick::Kick(Request req, User *user) : ICommand(req, user)
     {   
     
         Channel temp = Channel();
-        std::cout << temp.getName();
         this->channel = &temp;
     }
     this->permission = channel->getMode();


### PR DESCRIPTION
세그폴트로 종료되는 문제 > 파라미터 인덱스 넘치게 접근, 2에서 1로 알맞게 수정하고 
채널명 잘못넣었을때 파라미터를 아예 보내주지 않아서 size < 1일때 예외처리를 생성자에 추가함

킥후 밴리스트에 넣는 코드 추가

메시지는 보내고 킥하게 변경