### PR TITLE
Request Parser에서 간헐적으로 빈 문자열이 parameter에 추가되는 문제를 수정했습니다

### DIFF
--- a/Server/Server.cpp
+++ b/Server/Server.cpp
@@ -3,6 +3,7 @@
 #include <cstring>
 
 Server::Server(std::string password, int port) {
+  int optval = 1;
   this->password = password;
   this->port = port;
 
@@ -15,6 +16,7 @@ Server::Server(std::string password, int port) {
   sin.sin_family = AF_INET;
   sin.sin_addr.s_addr = INADDR_ANY;
   sin.sin_port = htons(port);
+  setsockopt(socket_fd, SOL_SOCKET, SO_REUSEADDR, &optval, sizeof(optval));
   if (bind(socket_fd, (struct sockaddr *)&sin, sizeof(sin)) == -1)
     throw std::runtime_error("Bind function failed");
   if (listen(socket_fd, LISTEN_QUEUE_SIZE) == -1)

--- a/request/Parameter.cpp
+++ b/request/Parameter.cpp
@@ -1,7 +1,7 @@
 #include "Parameter.hpp"
 
 static const std::string parameterDelimeter = " ";
-static const std::string trailerDelimeter = ":";
+static const std::string trailerDelimeter = " :";
 
 static void parseParameter(std::string parameter,
                            std::vector<std::string> &token, std::string &tr,


### PR DESCRIPTION
1. Request Parser의 Parameter 파싱 과정 중 trailer 구분자를 " :" 로 수정했습니다
2. 서버에서 포트를 재사용하도록 수정했습니다